### PR TITLE
33 adapt excel to new temporada (#76)

### DIFF
--- a/SMACB/CalendarioACB.py
+++ b/SMACB/CalendarioACB.py
@@ -6,6 +6,7 @@ from time import gmtime, strptime
 
 from Utils.Misc import FORMATOtimestamp
 from Utils.Web import DescargaPagina, MergeURL, getObjID
+
 from .SMconstants import URL_BASE
 
 calendario_URLBASE = "http://www.acb.com/calendario"

--- a/SMACB/PartidoACB.py
+++ b/SMACB/PartidoACB.py
@@ -13,8 +13,10 @@ import pandas as pd
 from babel.numbers import parse_number
 from bs4 import Tag
 
+from Utils.BoWtraductor import RetocaNombreJugador
 from Utils.Misc import BadParameters, BadString, ExtractREGroups
 from Utils.Web import DescargaPagina, ExtraeGetParams, getObjID
+
 from .PlantillaACB import PlantillaACB
 from .SMconstants import (BONUSVICTORIA, bool2esp, haGanado2esp, local2esp,
                           titular2esp)
@@ -107,16 +109,21 @@ class PartidoACB(object):
                 for datosJug in self.pendientes[l]:
                     if datosJug['nombre'] == '':
                         print("Datos insuficientes para encontrar ID. Partido: %s. %s" % (self, datosJug))
-                        newPendientes.append(datosJug)
-                        if datosJug['esJugador']:
-                            # Admitimos la pifia para entrenador pero no para jugadores
-                            raiser = True
+                        continue
+                        # newPendientes.append(datosJug)
+                        # if datosJug['esJugador']:
+                        #     # Admitimos la pifia para entrenador pero no para jugadores
+                        #     raiser = True
                     else:
                         if cachedTeam is None:
                             cachedTeam = PlantillaACB(id=datosJug['IDequipo'], edicion=datosJug['temporada'])
 
-                        newCode = cachedTeam.getCode(datosJug['nombre'], datosJug['dorsal'], datosJug['entrenador'],
-                                                     datosJug['esJugador'])
+                        nombreRetoc = RetocaNombreJugador(
+                            datosJug['nombre']) if ',' in datosJug['nombre'] else datosJug['nombre']
+
+                        newCode = cachedTeam.getCode(nombre=nombreRetoc, dorsal=datosJug['dorsal'],
+                                                     esTecnico=datosJug['entrenador'],
+                                                     esJugador=datosJug['esJugador'], umbral=1)
                         if newCode is not None:
                             datosJug['codigo'] = newCode
 

--- a/SMACB/PlantillaACB.py
+++ b/SMACB/PlantillaACB.py
@@ -2,9 +2,10 @@ from argparse import Namespace
 from time import gmtime
 
 from Utils.BoWtraductor import (CompareBagsOfWords, CreaBoW, NormalizaCadena,
-                                RetocaNombreJugador, comparaFrases)
+                                RetocaNombreJugador, comparaNombresPersonas)
 from Utils.Misc import onlySetElement
 from Utils.Web import DescargaPagina, MergeURL, creaBrowser, getObjID
+
 from .SMconstants import URL_BASE
 
 CLAVESFICHA = ['alias', 'nombre', 'lugarNac', 'fechaNac', 'posicion', 'altura', 'nacionalidad', 'licencia']
@@ -19,8 +20,9 @@ class PlantillaACB(object):
         home = kwargs.get('home', None)
         browser = kwargs.get('browser', None)
         config = kwargs.get('config', Namespace())
+        extraTrads = kwargs.get('otrosNombres', None)
 
-        data = descargaURLplantilla(self.URL, home, browser, config)
+        data = descargaURLplantilla(self.URL, home, browser, config, otrosNombres=extraTrads)
         self.timestamp = data.get('timestamp', gmtime())
 
         self.club = data.get('club', {})
@@ -43,13 +45,13 @@ class PlantillaACB(object):
         return result
 
     @staticmethod
-    def fromURL(urlPlantilla, home=None, browser=None, config=Namespace()):
+    def fromURL(urlPlantilla, home=None, browser=None, config=Namespace(), otrosNombres=None):
         if browser is None:
             browser = creaBrowser(config)
 
         probEd = getObjID(urlPlantilla, 'year', None)
         params = {'id': getObjID(urlPlantilla, 'id'), 'edicion': probEd, 'home': home, 'browser': browser,
-                  'config': config}
+                  'config': config, 'otrosNombres': otrosNombres}
 
         return PlantillaACB(**params)
 
@@ -65,6 +67,7 @@ class PlantillaACB(object):
         if esJugador:
             targetDict = self.jugadores
         elif esTecnico:
+            dorsal = None
             targetDict = self.tecnicos
         else:  # Ni jugador ni tecnico???
             raise ValueError("Jugador '%s' (%s) no es ni jugador ni técnico" % (
@@ -85,7 +88,7 @@ class PlantillaACB(object):
             else:  # Sin dorsal no es suficiente sólo con apellidos (apellidos o nombres muy comunes)
                 for jNombre in jData['nombre']:
                     dsSet = CreaBoW(NormalizaCadena(RetocaNombreJugador(jNombre)))
-                    if CompareBagsOfWords(setNombre, dsSet) > umbral:
+                    if CompareBagsOfWords(setNombre, dsSet) > 0:
                         resultSet.add(jCode)
 
         if not resultSet:  # Ni siquiera candidatos => nada que hacer
@@ -99,19 +102,19 @@ class PlantillaACB(object):
             jData = targetDict[jCode]
             for jNombre in jData['nombre']:
                 dsNormaliz = NormalizaCadena(RetocaNombreJugador(jNombre))
-                if comparaFrases(dsNormaliz, nombreNormaliz, umbral=umbral):
+                if comparaNombresPersonas(dsNormaliz, nombreNormaliz, umbral=umbral):
                     codeList.add(jCode)
 
         return onlySetElement(codeList)
 
 
-def descargaURLplantilla(urlPlantilla, home=None, browser=None, config=Namespace()):
+def descargaURLplantilla(urlPlantilla, home=None, browser=None, config=Namespace(), otrosNombres=None):
     if browser is None:
         browser = creaBrowser(config)
     try:
         pagPlant = DescargaPagina(urlPlantilla, home=home, browser=browser, config=config)
 
-        result = procesaPlantillaDescargada(pagPlant)
+        result = procesaPlantillaDescargada(pagPlant, otrosNombres=otrosNombres)
         result['URL'] = browser.get_url()
         result['timestamp'] = gmtime()
         result['edicion'] = encuentraUltEdicion(pagPlant)
@@ -123,7 +126,16 @@ def descargaURLplantilla(urlPlantilla, home=None, browser=None, config=Namespace
     return result
 
 
-def procesaPlantillaDescargada(plantDesc):
+def procesaPlantillaDescargada(plantDesc, otrosNombres=None):
+    """
+    Procesa el contenido de una página de plantilla
+
+    :param plantDesc: bs4 contenido de la página de la plantilla
+    :param otrosNombres: diccionario ID->set de nombres
+    :return:
+    """
+    auxTraducciones = otrosNombres if otrosNombres else dict()
+
     result = dict()
 
     result['jugadores'] = dict()
@@ -137,7 +149,12 @@ def procesaPlantillaDescargada(plantDesc):
     for bloqueDiv in cosasUtiles.find_all('div', {"class": "grid_plantilla"}):
         for jugArt in bloqueDiv.find_all("article"):
             data = dict()
-            data['nombre'] = set()
+
+            link = jugArt.find("a").attrs['href']
+            data['id'] = getObjID(link, 'ver')
+
+            # Carga con los nombres de una potencial traducción existente
+            data['nombre'] = set().union(auxTraducciones.get(data['id'], set()))
 
             if 'caja_jugador_medio_cuerpo' in jugArt.attrs['class'] or 'caja_jugador_cara' in jugArt.attrs['class']:
                 destClass = 'jugadores'
@@ -157,10 +174,8 @@ def procesaPlantillaDescargada(plantDesc):
 
             data['dorsal'] = jugArt.find("div", {"class": "dorsal"}).get_text().strip()
 
-            link = jugArt.find("a").attrs['href']
             data['URL'] = MergeURL(URL_BASE, link)
             data['URLimg'] = jugArt.find("img").attrs['src']
-            data['id'] = getObjID(link, 'ver')
 
             result[destClass][data['id']] = data
 
@@ -172,14 +187,15 @@ def procesaPlantillaDescargada(plantDesc):
             tds = list(row.find_all("td"))
 
             data = dict()
-            data['nombre'] = set()
-            data['dorsal'] = row.find("td", {"class": "dorsal"}).get_text().strip()
-            for sp in row.find("td", {"class": "jugador"}).find_all("span"):
-                data['nombre'].add(sp.get_text().strip())
 
             link = tds[1].find("a").attrs['href']
             data['URL'] = MergeURL(URL_BASE, link)
             data['id'] = getObjID(link, 'ver')
+
+            data['nombre'] = set().union(auxTraducciones.get(data['id'], set()))
+            data['dorsal'] = row.find("td", {"class": "dorsal"}).get_text().strip()
+            for sp in row.find("td", {"class": "jugador"}).find_all("span"):
+                data['nombre'].add(sp.get_text().strip())
 
             posics = {tds[2].find("span").get_text().strip()}
 
@@ -214,7 +230,7 @@ def encuentraUltEdicion(plantDesc):
     return result
 
 
-def descargaPlantillasCabecera(browser=None, config=Namespace()):
+def descargaPlantillasCabecera(browser=None, config=Namespace(), jugId2nombre=None):
     result = dict()
     if browser is None:
         browser = creaBrowser(config)
@@ -232,6 +248,6 @@ def descargaPlantillasCabecera(browser=None, config=Namespace()):
         urlFull = MergeURL(browser.get_url(), urlLink)
 
         idEq = getObjID(objURL=urlFull, clave='id')
-        result[idEq] = PlantillaACB.fromURL(urlFull, browser=browser, config=config)
+        result[idEq] = PlantillaACB.fromURL(urlFull, browser=browser, config=config, otrosNombres=jugId2nombre)
 
     return result

--- a/Utils/Misc.py
+++ b/Utils/Misc.py
@@ -181,3 +181,11 @@ def onlySetElement(myset):
     :return:
     """
     return list(myset.copy())[0] if isinstance(myset, (set, list)) and len(myset) == 1 else myset
+
+
+def cosaCorta(c1, c2):
+    return (c1 if len(c2) > len(c1) else c2)
+
+
+def cosaLarga(c1, c2):
+    return (c2 if len(c2) > len(c1) else c1)

--- a/creaExcel.py
+++ b/creaExcel.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from collections import defaultdict
+from statistics import mean, median, stdev
+from time import gmtime, mktime, strftime, time
+
+from configargparse import ArgumentParser
+from pandas import DataFrame, ExcelWriter
+
+from SMACB.ManageSMDataframes import (CATMERCADOFINAL, COLSPREC,
+                                      calculaDFcategACB, calculaDFconVars,
+                                      calculaDFprecedentes)
+from SMACB.PartidoACB import PartidoACB
+from SMACB.SMconstants import MINPRECIO, POSICIONES, PRECIOpunto
+from SMACB.SuperManager import SuperManagerACB
+from SMACB.TemporadaACB import TemporadaACB, calculaVars, calculaZ
+from Utils.Misc import FORMATOtimestamp, SubSet
+
+
+def jugadoresMezclaStatus(datos):
+    resultado = defaultdict(set)
+
+    for jug in datos:
+        datosJug = datos[jug]
+        if 'I-activo' not in datosJug:
+            (resultado[None]).add(jug)
+            continue
+
+        statusJug = datosJug['I-activo']
+        (resultado[statusJug]).add(jug)
+
+    return resultado
+
+
+def CuentaClavesPartido(x):
+    if type(x) is not dict:
+        raise ValueError("CuentaClaves: necesita un diccionario")
+
+    resultado = defaultdict(int)
+
+    for clave in x:
+        valor = x[clave]
+
+        if type(valor) is not PartidoACB:
+            print("CuentaClaves: objeto de clave '%s' no es un PartidoACB, %s" % (clave, type(valor)))
+            continue
+
+        for subclave in valor.__dict__.keys():
+            resultado[subclave] += 1
+
+    return resultado
+
+
+def mezclaJugadores(jugTemporada, jugSuperManager):
+    resultado = defaultdict(dict)
+
+    for claveSM in jugSuperManager:
+        for jug in jugSuperManager[claveSM]:
+            resultado[jug][claveSM] = jugSuperManager[claveSM][jug]
+
+    for claveTM in jugTemporada:
+        for jug in jugTemporada[claveTM]:
+            resultado[jug][claveTM] = jugTemporada[claveTM][jug]
+
+    return resultado
+
+
+def preparaDatosComunes(datosMezclados):
+    resultado = dict()
+    datosCabecera = dict()
+
+    titularCabecera = ['Pos', 'Cupo', 'Lesion', 'Nombre', 'Equipo', 'Promedio Val', 'Precio',
+                       'Proximo Rival', 'Precio punto']
+
+    jugadoresActivos = jugadoresMezclaStatus(datosMezclados)[True]
+    # jugadoresInactivos = jugPorStatus[False]
+    jugDataActivos = {x: datosMezclados[x] for x in jugadoresActivos}
+
+    for jug in jugDataActivos:
+        cabecJug = list()
+        datosJug = jugDataActivos[jug]
+
+        for campo in ['I-pos', 'I-cupo', 'I-lesion', 'I-nombre', 'I-equipo', 'I-promVal', 'I-precio']:
+            if campo in datosJug:
+                if campo == 'I-pos':
+                    cabecJug.append(POSICIONES[datosJug[campo]])
+                    continue
+                elif campo == 'I-lesion':
+                    salud = "Lesionado" if datosJug[campo] else ""
+                    cabecJug.append(salud)
+                    continue
+
+                cabecJug.append(datosJug[campo])
+            else:
+                print("Falla clave:", campo, datosJug)
+                exit(1)
+
+        proxPartido = ("@" if datosJug['I-proxFuera'] else "") + datosJug['I-rival']
+        cabecJug.append(proxPartido)
+        costePunto = (datosJug['I-precio'] / datosJug['I-promVal']) if (datosJug['I-promVal']) > 0 else "-"
+        cabecJug.append(costePunto)
+        datosCabecera[jug] = cabecJug
+
+    claves = list(map(lambda x: x[0], sorted(list(map(lambda x: (x, jugDataActivos[x]['I-precio']), jugDataActivos)),
+                                             reverse=True,
+                                             key=lambda x: x[1])))
+
+    resultado['claves'] = claves
+    resultado['cabeceraLinea'] = datosCabecera
+    resultado['titularCabecera'] = titularCabecera
+
+    return resultado
+
+
+def preparaExcel(supermanager, temporada, nomFichero="/tmp/SM.xlsx"):
+    dfSuperManager = supermanager.superManager2dataframe(
+        nombresJugadores=temporada.tradJugadores['id2nombres'])  # Needed to get player position from all players
+    dfTemporada = temporada.extraeDataframeJugadores().merge(dfSuperManager[['codigo', 'pos']], how='left')
+    # All data fall playrs
+    dfUltMerc = supermanager.mercado[supermanager.ultimoMercado].mercado2dataFrame()
+    dfUltMerc['activo'] = True
+    dfUltMerc['Alta'] = 'S'
+
+    dfVZ = calculaZ(dfTemporada, 'V', useStd=True)
+
+    varsVZ = calculaVars(dfTemporada, 'V')
+    varsVsmZ = calculaVars(dfTemporada, 'Vsm')
+    varsVD = calculaVars(dfTemporada, 'V', useStd=False)
+    varsVsmD = calculaVars(dfTemporada, 'Vsm', useStd=False)
+
+    dfPredsV = calculaDFconVars(dfTemp=dfTemporada, dfMerc=dfUltMerc, clave="V", filtroFechas=None)
+    dfPredsVsm = calculaDFconVars(dfTemp=dfTemporada, dfMerc=dfUltMerc, clave="Vsm", filtroFechas=None)
+
+    # numJornadas = temporada.maxJornada()
+    # nombreJornadas = {False: temporada.Calendario.nombresJornada()[:numJornadas],
+    #                   True: ['J 0'] + temporada.Calendario.nombresJornada()[:numJornadas]}
+
+    def preparaFormatos(workbook):
+        resultado = dict()
+
+        for r in 'VD':
+            for v in 'LF':
+                newKey = r + v
+                resultado[newKey] = workbook.add_format({'bg_color': 'green' if v == 'L' else 'blue'})
+                resultado[newKey + 'd'] = workbook.add_format({'bg_color': 'green' if v == 'L' else 'blue'})
+                resultado[newKey + 'n'] = workbook.add_format({'bg_color': 'green' if v == 'L' else 'blue'})
+                resultado[newKey + 'dn'] = workbook.add_format({'bg_color': 'green' if v == 'L' else 'blue'})
+                resultado[newKey + 'n'].set_italic()
+                resultado[newKey + 'dn'].set_italic()
+
+                if r == 'V':
+                    resultado[newKey].set_bold()
+                    resultado[newKey + 'd'].set_bold()
+                    resultado[newKey + 'n'].set_bold()
+                    resultado[newKey + 'dn'].set_bold()
+
+        resultado['datosComunes'] = workbook.add_format({'num_format': '0.00;[Red]-0.00'})
+        resultado['cabecera'] = workbook.add_format({'bold': True, 'align': 'center'})
+        resultado['nulo'] = workbook.add_format()
+
+        resultado['smBaja'] = workbook.add_format({'bg_color': 'grey'})
+
+        return resultado
+
+    def preparaHojaMercado(excelwriter, supermanager, temporada, listaformatos):
+        dfSuperManager = supermanager.superManager2dataframe(
+            nombresJugadores=temporada.tradJugadores['id2nombres'], )  # Needed to get player position from all players
+        dfTemporada = temporada.extraeDataframeJugadores().merge(dfSuperManager[['codigo', 'pos']], how='left')
+        # All data fall playrs
+        dfUltMerc = supermanager.mercado[supermanager.ultimoMercado].mercado2dataFrame()
+        auxPrecioObj = DataFrame({'obj': (dfUltMerc['promVal'] * PRECIOpunto), 'min': MINPRECIO}).max(axis=1)
+        dfUltMerc['precObj'] = auxPrecioObj
+        dfUltMerc['distAObj'] = dfUltMerc['precio'] - dfUltMerc['precObj']
+
+        dfUltMerc['Alta'] = 'S'
+
+        COLSDIFPRECIO = ['precObj', 'distAObj']
+
+        dfPrecV = calculaDFprecedentes(dfTemporada, dfUltMerc, 'V')
+        dfPrecVsm = calculaDFprecedentes(dfTemporada, dfUltMerc, 'Vsm')
+        if dfPrecV.empty:
+            antecColumns = CATMERCADOFINAL + COLSDIFPRECIO
+            df2show = dfUltMerc[antecColumns].set_index('codigo')
+        else:
+            antecColumns = CATMERCADOFINAL + COLSDIFPRECIO + COLSPREC
+            df2show = dfUltMerc.merge(dfPrecV, how='left').merge(dfPrecVsm, how='left')[antecColumns].set_index(
+                'codigo')
+
+        creaHoja(writer, 'Mercado', df2show, formatos, colsToFreeze=len(CATMERCADOFINAL) - 1)
+
+    def calculaFormato(victoria, local, hajugado, vdecimal):
+        if victoria is None:
+            return "nulo"
+        resultado = ""
+        resultado += "V" if victoria else "D"
+        resultado += "L" if local else "F"
+        if vdecimal:
+            resultado += "d"
+        if hajugado is not None and hajugado:
+            pass
+        else:
+            resultado += "n"
+
+        return resultado
+
+    def creaHoja(excelwriter, nombre, dataframe, formatos, rowsToFreeze=1, colsToFreeze=0, useIndex=False):
+
+        dataframe.to_excel(excelwriter, sheet_name=nombre, freeze_panes=(rowsToFreeze, colsToFreeze), index=useIndex)
+
+        sht = excelwriter.book.sheetnames[nombre]
+        sht.autofilter(sht.dim_rowmin, sht.dim_colmin, sht.dim_rowmax, sht.dim_colmax)
+        for r in range(sht.dim_rowmin + 1, sht.dim_rowmax + 1):
+            sht.set_row(r, cell_format=formatos['datosComunes'])
+
+    def addMetadata(excelwriter, sm, tm):
+
+        metadata = ["Cargados datos SuperManager de %s" % strftime(FORMATOtimestamp, sm.timestamp),
+                    "Cargada información de temporada de %s" % strftime(FORMATOtimestamp, tm.timestamp),
+                    "Ejecutado en %s" % strftime(FORMATOtimestamp, gmtime())]
+
+        ws = excelwriter.book.add_worksheet("Metadata")
+        fila = 0
+        columna = 0
+        for l in metadata:
+            ws.write(fila, columna, l)
+            fila += 1
+
+    with ExcelWriter(nomFichero) as writer:
+        formatos = preparaFormatos(writer.book)
+
+        preparaHojaMercado(writer, sm, temporada, formatos)
+
+        creaHoja(writer, 'V', calculaDFcategACB(dfTemporada, dfSuperManager, 'V'), formatos,
+                 colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'Vsm', calculaDFcategACB(dfTemporada, dfSuperManager, 'Vsm'), formatos,
+                 colsToFreeze=len(CATMERCADOFINAL) + 3)
+
+        creaHoja(writer, 'Z-V', calculaDFcategACB(dfVZ, dfSuperManager, 'Z-V'), formatos,
+                 colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'P', calculaDFcategACB(dfTemporada, dfSuperManager, 'P'), formatos,
+                 colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'A', calculaDFcategACB(dfTemporada, dfSuperManager, 'A'), formatos,
+                 colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'Rebotes', calculaDFcategACB(dfTemporada, dfSuperManager, 'REB-T'), formatos,
+                 colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'Triples', calculaDFcategACB(dfTemporada, dfSuperManager, 'T3-C'), formatos,
+                 colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'PredicsV-Z', dfPredsV, formatos, colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'PredicsVsm-Z', dfPredsVsm, formatos, colsToFreeze=len(CATMERCADOFINAL) + 3)
+        creaHoja(writer, 'TEMPORADA', dfTemporada, formatos, colsToFreeze=len(CATMERCADOFINAL) + 3)
+
+        for comb in varsVZ:
+            nombreHoja = "V-Z-" + comb
+            indexCols = []
+            if 'R' in comb:
+                indexCols.append('CODrival')
+            if 'P' in comb:
+                indexCols.append('pos')
+            if 'L' in comb:
+                indexCols.append('esLocal')
+
+            creaHoja(writer, nombreHoja, varsVZ[comb].set_index(indexCols), formatos, colsToFreeze=len(indexCols),
+                     useIndex=True)
+
+        for comb in varsVsmZ:
+            nombreHoja = "Vsm-Z-" + comb
+            indexCols = []
+            if 'R' in comb:
+                indexCols.append('CODrival')
+            if 'P' in comb:
+                indexCols.append('pos')
+            if 'L' in comb:
+                indexCols.append('esLocal')
+
+            creaHoja(writer, nombreHoja, varsVsmZ[comb].set_index(indexCols), formatos, colsToFreeze=len(indexCols),
+                     useIndex=True)
+
+        for comb in varsVD:
+            nombreHoja = "V-D-" + comb
+            indexCols = []
+            if 'R' in comb:
+                indexCols.append('CODrival')
+            if 'P' in comb:
+                indexCols.append('pos')
+            if 'L' in comb:
+                indexCols.append('esLocal')
+
+            creaHoja(writer, nombreHoja, varsVD[comb].set_index(indexCols), formatos, colsToFreeze=len(indexCols),
+                     useIndex=True)
+
+        for comb in varsVsmD:
+            nombreHoja = "Vsm-D-" + comb
+            indexCols = []
+            if 'R' in comb:
+                indexCols.append('CODrival')
+            if 'P' in comb:
+                indexCols.append('pos')
+            if 'L' in comb:
+                indexCols.append('esLocal')
+
+            creaHoja(writer, nombreHoja, varsVsmD[comb].set_index(indexCols), formatos, colsToFreeze=len(indexCols),
+                     useIndex=True)
+
+        addMetadata(writer, sm, temporada)
+
+
+def infoJugador(datosJugador, numdias=0):
+    resultados = dict()
+    Parts = dict()
+
+    def auxDict():
+        return defaultdict(int)
+
+    Rjug = defaultdict(auxDict)
+    Rvict = defaultdict(auxDict)
+
+    haJugado = datosJugador['haJugado']
+    esLocal = datosJugador['esLocal']
+    victoria = datosJugador['haGanado']
+
+    if numdias:
+        fecha = [x for x in datosJugador['FechaHora']]
+        partIDX = [i for i in range(len(haJugado)) if haJugado[i] is not None and
+                   mktime(fecha[i]) > time() - (numdias * 24 * 3600)]
+    else:
+        partIDX = [i for i in range(len(haJugado)) if haJugado[i] is not None]
+
+    Parts['total'] = [i for i in partIDX if esLocal[i] is not None]
+    Parts['local'] = [i for i in Parts['total'] if esLocal[i]]
+    Parts['fuera'] = [i for i in Parts['total'] if not esLocal[i]]
+
+    for k in Parts:
+        for i in Parts[k]:
+            Rjug[k][haJugado[i]] += 1
+            Rvict[k][victoria[i]] += 1
+
+    for clave in ['V', 'P', 'A', 'T3-C', 'REB-T', 'Segs']:
+        if clave not in datosJugador:
+            continue
+        resultados[clave] = defaultdict(dict)
+        for k in Parts:
+            auxVals = SubSet(datosJugador[clave], Parts[k])
+            lv = len(auxVals)
+
+            resultados[clave][k]['min'] = min(auxVals) if lv else "-"
+            resultados[clave][k]['max'] = max(auxVals) if lv else "-"
+            resultados[clave][k]['median'] = median(auxVals) if lv else "-"
+            resultados[clave][k]['mean'] = mean(auxVals) if lv else "-"
+            resultados[clave][k]['stdev'] = stdev(auxVals) if lv > 1 else "-"
+
+    resultados['jug'] = Rjug
+    resultados['vict'] = Rvict
+
+    return resultados
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+
+    parser.add('-v', dest='verbose', action="count", env_var='SM_VERBOSE', required=False, default=0)
+    parser.add('-d', dest='debug', action="store_true", env_var='SM_DEBUG', required=False, default=False)
+
+    parser.add('-i', dest='infile', type=str, env_var='SM_INFILE', required=True)
+    parser.add('-t', dest='temporada', type=str, env_var='SM_TEMPORADA', required=True)
+
+    parser.add('-o', dest='outfile', type=str, env_var='SM_OUTFILE', required=False)
+    parser.add('-f', dest='filter', type=int, env_var='SM_DAYS', required=False, default=0)
+
+    args = parser.parse_args()
+
+    sm = SuperManagerACB()
+
+    sm.loadData(args.infile)
+    print("Cargados datos SuperManager de %s" % strftime(FORMATOtimestamp, sm.timestamp))
+
+    temporada = TemporadaACB()
+    temporada.cargaTemporada(args.temporada)
+    print("Cargada información de temporada de %s" % strftime(FORMATOtimestamp, temporada.timestamp))
+
+    if 'outfile' in args and args.outfile:
+        preparaExcel(sm, temporada, args.outfile)


### PR DESCRIPTION
* Arreglada asignación de columna de valores en Mercado

* Partidor: Retoca el nombre de jugador si hay coma para hacerlo BoW friendly

* Plantilla: permite arrastrar nombres coleccionados en fichas y temporada porque la plantilla no es suficiente

* Utils/BoWtraductor:
* comparaFrases pasa a comparaNombresPersonas
* En comparaNombresPersonas emplea número de similitudes para que el umbral signifique algo
* Minimo proceso, que no tengo claro que mejore algo, de cosas de en medio y parte final

* Recuperada exportación a Dataframe

* En la exportación de mercado a DF, incluye los jugadores sin link.
* En SuperManager, la exportación de mercados almacenados a DF incluye lógica para obtener códigos ACB de jugadores.

* Flake8

* Version actualizada de creaExcel