### PR TITLE
93 iss253 arreglar extraccion compo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,8 +57,8 @@ python InformeSuperManager.py -i /home/calba/devel/SuperManager/full/SM2017.late
 ## Competiciones y temporadas
 
 * Liga: LACB cod_edicion 28 (1983-1984)
-* Copa: CREY cod_edicion  48 (1983-1984) http://www.acb.com/partcopa.php?cod_edicion1=48&x=8&y=6&cod_competicion=CREY
-* Supercopa: SCOPA cod_edicion 1 (1985) http://www.acb.com/fichas/SCOPA1001.php (Ojo: el num de competicion no se rellena con ceros)
+* Copa: CREY cod_edicion  48 (1983-1984) https://www.acb.com/partcopa.php?cod_edicion1=48&x=8&y=6&cod_competicion=CREY
+* Supercopa: SCOPA cod_edicion 1 (1985) https://www.acb.com/fichas/SCOPA1001.php (Ojo: el num de competicion no se rellena con ceros)
 
 # TODO
 

--- a/SMACB/CalendarioACB.py
+++ b/SMACB/CalendarioACB.py
@@ -14,13 +14,13 @@ from .Constants import URL_BASE, PLAYOFFFASE
 
 logger = logging.getLogger()
 
-calendario_URLBASE = "http://www.acb.com/calendario"
+calendario_URLBASE = "https://www.acb.com/calendario"
 
-# http://www.acb.com/calendario/index/temporada_id/2018
-# http://www.acb.com/calendario/index/temporada_id/2019/edicion_id/952
-template_CALENDARIOYEAR = "http://www.acb.com/calendario/index/temporada_id/{year}"
-template_CALENDARIOFULL = "http://www.acb.com/calendario/index/temporada_id/{year}/edicion_id/{compoID}"
-template_PARTIDOSEQUIPO = "http://www.acb.com/club/partidos/id/{idequipo}"
+# https://www.acb.com/calendario/index/temporada_id/2018
+# https://www.acb.com/calendario/index/temporada_id/2019/edicion_id/952
+template_CALENDARIOYEAR = "https://www.acb.com/calendario/index/temporada_id/{year}"
+template_CALENDARIOFULL = "https://www.acb.com/calendario/index/temporada_id/{year}/edicion_id/{compoID}"
+template_PARTIDOSEQUIPO = "https://www.acb.com/club/partidos/id/{idequipo}"
 
 ETIQubiq = ['local', 'visitante']
 

--- a/SMACB/CalendarioACB.py
+++ b/SMACB/CalendarioACB.py
@@ -369,14 +369,18 @@ def compo2clave(listaCompos):
     :param listaCompos:
     :return:
     """
+    PATliga = r'^liga\W'
+    PATsupercopa = r'^supercopa\W'
+    PATcopa = r'^copa\W.*rey'
+
     result = dict()
 
     for idComp, label in listaCompos.items():
-        if 'liga' in label.lower():
+        if re.match(PATliga, label, re.IGNORECASE):
             result['LACB'] = idComp
-        elif 'supercopa' in label.lower():
+        elif re.match(PATsupercopa, label, re.IGNORECASE):
             result['SCOPA'] = idComp
-        elif 'copa' in label.lower():
+        elif re.match(PATcopa, label, re.IGNORECASE):
             result['COPA'] = idComp
 
     return result

--- a/SMACB/Constants.py
+++ b/SMACB/Constants.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from CAPcore.Misc import BadParameters
 
-URL_BASE = "http://www.acb.com"
+URL_BASE = "https://www.acb.com"
 
 bool2esp = {True: "S", False: "N"}
 haGanado2esp = {True: "V", False: "D"}

--- a/SMACB/FichaJugador.py
+++ b/SMACB/FichaJugador.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from time import gmtime
 from typing import Optional
@@ -307,6 +308,7 @@ def descargaYparseaURLficha(urlFicha, datosPartido: Optional[dict] = None, home=
             auxResult['sinDatos'] = True
             auxResult['alias'] = datosPartido['nombre']
 
+        logging.info("Descargando ficha jugador '%s'", urlFicha)
         fichaJug = downloadPage(urlFicha, home=home, browser=browser, config=config)
 
         auxResult['URL'] = browser.get_url()

--- a/SMACB/PartidoACB.py
+++ b/SMACB/PartidoACB.py
@@ -72,7 +72,7 @@ class PartidoACB():
 
     def procesaPartido(self, content: DownloadedPage):
         raiser = False
-        self.timestamp = getattr(content,'timestamp',gmtime())
+        self.timestamp = getattr(content, 'timestamp', gmtime())
 
         if 'source' in content:
             self.url = content.source

--- a/SMACB/PartidoACB.py
+++ b/SMACB/PartidoACB.py
@@ -18,7 +18,7 @@ from Utils.Web import getObjID, prepareDownloading
 from .Constants import (bool2esp, haGanado2esp, local2esp, LocalVisitante, OtherLoc, titular2esp)
 from .PlantillaACB import PlantillaACB
 
-templateURLficha = "http://www.acb.com/fichas/%s%i%03i.php"
+templateURLficha = "https://www.acb.com/fichas/%s%i%03i.php"
 
 
 class PartidoACB():

--- a/SMACB/TemporadaACB.py
+++ b/SMACB/TemporadaACB.py
@@ -289,7 +289,7 @@ class TemporadaACB:
         if self.descargaPlantillas:
 
             browser, config = prepareDownloading(browser, config, URL_BASE)
-
+            logger.info("%s Actualizando plantillas", self)
             datosPlantillas = descargaPlantillasCabecera(browser, config)
             for p_id in datosPlantillas:
                 if p_id not in self.plantillas:

--- a/Utils/Web.py
+++ b/Utils/Web.py
@@ -41,7 +41,7 @@ def prepareDownloading(browser, config, urlRef: Optional[str] = None):
 
 
 def generaURLPlantilla(plantilla, urlRef: str):
-    # http://www.acb.com/club/plantilla/id/6/temporada_id/2016
+    # https://www.acb.com/club/plantilla/id/6/temporada_id/2016
     params = ['/club', 'plantilla', 'id', plantilla.id]
     if plantilla.edicion is not None:
         params += ['temporada_id', plantilla.edicion]

--- a/Utils/combinatorics.py
+++ b/Utils/combinatorics.py
@@ -26,7 +26,7 @@ specified collection of items, with ks[i] items in the ith group, i= 0, 1, 2,
 means that the relative order of equal- size groups is important; the order of
 the items within any group is not important.  The total number of combinations
 generated is given by the multinomial coefficient formula (see
-http://en.wikipedia.org/wiki/Multinomial_theorem#Multinomial_coefficients).
+https://en.wikipedia.org/wiki/Multinomial_theorem#Multinomial_coefficients).
 
 m_way_unordered_combinations(items, ks): This function returns a generator that
 produces all m-way unordered combinations from the specified collection of
@@ -135,7 +135,7 @@ partitions(n): 'In number theory and combinatorics, a partition of a positive
 integer n, also called an integer partition, is a way of writing n as a sum of
 positive integers. Two sums that differ only in the order of their summands are
 considered to be the same partition.'  The quote is from
-http://en.wikipedia.org/wiki/Partition_(number_theory).  We can generate all
+https://en.wikipedia.org/wiki/Partition_(number_theory).  We can generate all
 partitions of an integer using `unlabeled_balls_in_unlabeled_boxes`.
 
 off_by_one(n): This function returns a generator that enumerates all possible
@@ -924,7 +924,7 @@ def partitions(n):
     also called an integer partition, is a way of writing n as a sum of positive
     integers.  Two sums that differ only in the order of their summands are
     considered to be the same partition.'  The quote is from
-    http://en.wikipedia.org/wiki/Partition_(number_theory).  We can generate all
+    https://en.wikipedia.org/wiki/Partition_(number_theory).  We can generate all
     partitions of an integer using `unlabeled_balls_in_unlabeled_boxes`.
 
     Note: This is an inefficient method for generating partitions.  `partitions2`

--- a/scripts/getTemporada.sh
+++ b/scripts/getTemporada.sh
@@ -55,6 +55,8 @@ else
   ORIGPARAM="-f"
 fi
 
+export PYTHONPATH=${PYTHONPATH:-}:${WRKDIR}
+
 python ${WRKDIR}/bin/DescargaTemporada.py ${ORIGPARAM} -o ${DESTSMFILE} -b
 
 if [ $? = 0 ]


### PR DESCRIPTION
Cambia el sistema de detección de la competición en el calendario para usar RE's en lugar de "patrón in cadena".

Por otro lado (cambios y arreglos):
* Convierte URLs a https con lo que se ahorrará tiempo y tráfico en redirecciones
* Trazas nuevas
* Fija el PYTHONPAth en getTemporada.sh